### PR TITLE
Remove link without href

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,7 +146,7 @@
                 <div class="col-md-2 text-center">
                     <div class="speakerPerson">
                         <img src="img/speakers/jeff.png" class="img-circle">
-                        <h4><a>Dr. Jeff Chastine</a></h4>
+                        <h4>Dr. Jeff Chastine</h4>
                         <p></p>
                     </div>
                 </div>


### PR DESCRIPTION
@katdrobnjakovic 

Dr. Jeff Chastine's name appears as a link (underline & colour change on hover) but there is no `href` on this link. This removes the tag entirely since we don't have a link. It now behaves the same way as Camille Fournier's name: just a name in a `h4` tag.
